### PR TITLE
Update to add required methods to SpiNNaker class

### DIFF
--- a/spynnaker8/spinnaker.py
+++ b/spynnaker8/spinnaker.py
@@ -1,6 +1,6 @@
 # pynn imports
 from pyNN.common import control as pynn_control
-from pyNN.random import RandomDistribution
+from pyNN.random import RandomDistribution, NumpyRNG
 
 from spynnaker.pyNN.spinnaker_common import SpiNNakerCommon
 
@@ -378,3 +378,20 @@ class SpiNNaker(SpiNNakerCommon, pynn_control.BaseState):
     @staticmethod
     def get_random_distribution():
         return RandomDistribution
+
+    # The following methods need to be declared in this class
+
+    @staticmethod
+    def is_a_pynn_random(thing):
+        return isinstance(thing,RandomDistribution)
+
+    @staticmethod
+    def get_pynn_NumpyRNG():
+        return NumpyRNG()
+
+    # These methods need to be declared but they are not used in sPyNNaker8 / pynn0.8
+    def create_population(self):
+        return 0
+
+    def create_projection(self):
+        return 0

--- a/spynnaker8/spinnaker.py
+++ b/spynnaker8/spinnaker.py
@@ -383,13 +383,14 @@ class SpiNNaker(SpiNNakerCommon, pynn_control.BaseState):
 
     @staticmethod
     def is_a_pynn_random(thing):
-        return isinstance(thing,RandomDistribution)
+        return isinstance(thing, RandomDistribution)
 
     @staticmethod
     def get_pynn_NumpyRNG():
         return NumpyRNG()
 
-    # These methods need to be declared but they are not used in sPyNNaker8 / pynn0.8
+    # These methods need to be declared but they are not used
+    # in sPyNNaker8 / pynn0.8
     def create_population(self):
         return 0
 


### PR DESCRIPTION
create_population and create_projection are not used by
sPyNNaker8 due to the change in the Population and Projection
methods between pynn0.7 and pynn0.8