### PR TITLE
Remove the exit function as it can cause issues (not done in pyNN 0.7)

### DIFF
--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -329,13 +329,6 @@ def list_standard_models():
     return results
 
 
-@atexit.register
-def _stop_on_spinnaker():
-    # Stop SpiNNaker simulation
-    if globals_variables.has_simulator():
-        globals_variables.get_simulator().stop()
-
-
 def set_number_of_neurons_per_core(neuron_type, max_permitted):
     """ Sets a ceiling on the number of neurons of a given type that can be\
         placed on a single core.

--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -1,5 +1,4 @@
 # common imports
-import atexit
 import numpy as __numpy
 
 # pynn imports


### PR DESCRIPTION
Fix for SpiNNakerManchester/sPyNNaker#372

Removes the exit function that doesn't exist in pyNN 0.7 (seems to have come from Jamie's code).