### PR TITLE
Speed up data extractor

### DIFF
--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -135,11 +135,16 @@ __all__ = [
     'external_devices', 'extra_models',
     # Stuff that we define
     'end', 'setup', 'run', 'run_until', 'run_for', 'num_processes', 'rank',
-    'reset', 'set_number_of_neurons_per_core',
+    'reset', 'set_number_of_neurons_per_core', 'get_projections_data',
     'Projection',
     'get_current_time', 'create', 'connect', 'get_time_step', 'get_min_delay',
     'get_max_delay', 'initialize', 'list_standard_models', 'name',
     'num_processes', 'record', 'record_v', 'record_gsyn']
+
+
+def get_projections_data(projection_data):
+    return globals_variables.get_simulator().get_projections_data(
+        projection_data)
 
 
 def setup(timestep=pynn_control.DEFAULT_TIMESTEP,


### PR DESCRIPTION
gives us a 5.4 times speed up on simple synfire chain. likely to give more for larger sims. 

depends upon the following prs:

- [ ] https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/229
- [ ] https://github.com/SpiNNakerManchester/PACMAN/pull/131
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker7/pull/41
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker/pull/429
- [ ] https://github.com/SpiNNakerManchester/SpiNNMan/pull/100
- [ ] https://github.com/SpiNNakerManchester/SpiNNMachine/pull/53
- [ ] https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/71



Note that this work is not finished, but is stable. Future work will come which will increase this even further