### PR TITLE
Keep data in matrix

### DIFF
--- a/spynnaker8/models/data_cache.py
+++ b/spynnaker8/models/data_cache.py
@@ -106,7 +106,7 @@ class DataCache(object):
         """
         return self._cache[variable]
 
-    def save_data(self, variable, data, ids, units):
+    def save_data(self, variable, data, ids, units, sampling_interval):
         """
         Saves the data for one variable in this segment
         :param variable: name of variable data applies to
@@ -120,5 +120,5 @@ class DataCache(object):
         :rtype None
         """
         self._rec_datetime = datetime.now()
-        variable_cache = VariableCache(data, ids, units)
+        variable_cache = VariableCache(data, ids, units, sampling_interval)
         self._cache[variable] = variable_cache

--- a/spynnaker8/models/data_cache.py
+++ b/spynnaker8/models/data_cache.py
@@ -98,19 +98,19 @@ class DataCache(object):
         """
         return self._cache[variable]
 
-    def save_data(self, variable, data, ids, units, sampling_interval):
+    def save_data(self, variable, data, indexes, units, sampling_interval):
         """
         Saves the data for one variable in this segment
         :param variable: name of variable data applies to
         :type variable: str
         :param data: raw data in spynakker format
         :type data: nparray
-        :param ids: ids for which data should be returned
+        :param indexes: population indexes for which data should be returned
         :type nparray
         :param units: the units in which the data is
         :type units: str
         :rtype None
         """
         self._rec_datetime = datetime.now()
-        variable_cache = VariableCache(data, ids, units, sampling_interval)
+        variable_cache = VariableCache(data, indexes, units, sampling_interval)
         self._cache[variable] = variable_cache

--- a/spynnaker8/models/populations/population.py
+++ b/spynnaker8/models/populations/population.py
@@ -252,12 +252,14 @@ class Population(PyNNPopulationCommon, Recorder):
             else:
                 msg = "Only one type of data at a time is supported"
                 raise exceptions.ConfigurationException(msg)
-        return self._get_recorded_variable(variable)
+        if variable == SPIKES:
+            return self._get_spikes(SPIKES)
+        return self._get_recorded_pynn7(variable)
 
     def get_spike_counts(self, gather=True):
         """ Return the number of spikes for each neuron.
         """
-        spikes = self._get_recorded_variable(SPIKES)
+        spikes = self._get_spikes(SPIKES)
         return PyNNPopulationCommon.get_spike_counts(self, spikes, gather)
 
     def find_units(self, variable):

--- a/spynnaker8/models/populations/population.py
+++ b/spynnaker8/models/populations/population.py
@@ -253,13 +253,13 @@ class Population(PyNNPopulationCommon, Recorder):
                 msg = "Only one type of data at a time is supported"
                 raise exceptions.ConfigurationException(msg)
         if variable == SPIKES:
-            return self._get_spikes(SPIKES)
+            return self._get_spikes()
         return self._get_recorded_pynn7(variable)
 
     def get_spike_counts(self, gather=True):
         """ Return the number of spikes for each neuron.
         """
-        spikes = self._get_spikes(SPIKES)
+        spikes = self._get_spikes()
         return PyNNPopulationCommon.get_spike_counts(self, spikes, gather)
 
     def find_units(self, variable):

--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -191,10 +191,10 @@ class Recorder(RecordingCommon):
                     sampling_interval=sampling_interval,
                     label=self._population.label)
             else:
-                (data, ids, sampling_interval) = self._get_recorded_matrix(
+                (data, indexes, sampling_interval) = self._get_recorded_matrix(
                     variable)
-                indexes = numpy.array(
-                    [self._population.id_to_index(atom_id) for atom_id in ids])
+                ids = numpy.array(
+                    [self._population.index_to_id(index) for index in indexes])
                 read_in_signal(
                     segment=segment,
                     block=block,

--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -120,11 +120,11 @@ class Recorder(RecordingCommon):
                 first_id=self._population._first_id)
 
             for variable in variables:
-                data = self._get_recorded_variable(variable)
-                ids = sorted(
-                    self._filter_recorded(self._indices_to_record[variable]))
+                (data, ids, sampling_interval) = self._get_recorded_matrix(
+                    variable)
                 data_cache.save_data(variable=variable, data=data, ids=ids,
-                                     units=self._get_units(variable))
+                                     units=self._get_units(variable),
+                                     sampling_interval=sampling_interval)
             self._data_cache[segment_number] = data_cache
 
     def _filter_recorded(self, filter_ids):

--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -250,6 +250,7 @@ class Recorder(RecordingCommon):
                     indexes=indexes,
                     variable=variable,
                     recording_start_time=data_cache.recording_start_time,
+                    sampling_interval=data_cache.sampling_interval,
                     units=variable_cache.units,
                     label=data_cache.label)
 

--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -122,7 +122,7 @@ class Recorder(RecordingCommon):
                 if variable == SPIKES:
                     data = self._get_spikes()
                     sampling_interval = self._population._vertex. \
-                        get_sampling_interval(variable)
+                        get_spikes_sampling_interval()
                     ids = sorted(self._filter_recorded(
                         self._indices_to_record[variable]))
                 else:
@@ -180,7 +180,7 @@ class Recorder(RecordingCommon):
                 indexes = numpy.array(
                     [self._population.id_to_index(atom_id) for atom_id in ids])
                 sampling_interval = self._population._vertex. \
-                    get_sampling_interval(variable)
+                    get_spikes_sampling_interval()
                 read_in_spikes(
                     segment=segment,
                     spikes=self._get_spikes(),

--- a/spynnaker8/models/variable_cache.py
+++ b/spynnaker8/models/variable_cache.py
@@ -7,7 +7,7 @@ class VariableCache(object):
     """
     __slots__ = ("_data", "_ids", "_units")
 
-    def __init__(self, data, ids, units):
+    def __init__(self, data, ids, units, sampling_interval):
         """
 
         :param data: raw data in spynakker format
@@ -20,6 +20,7 @@ class VariableCache(object):
         self._data = data
         self._ids = ids
         self._units = units
+        self._sampling_interval = sampling_interval
 
     @property
     def data(self):

--- a/spynnaker8/models/variable_cache.py
+++ b/spynnaker8/models/variable_cache.py
@@ -33,3 +33,7 @@ class VariableCache(object):
     @property
     def units(self):
         return self._units
+
+    @property
+    def sampling_interval(self):
+        return self._sampling_interval

--- a/spynnaker8/models/variable_cache.py
+++ b/spynnaker8/models/variable_cache.py
@@ -5,7 +5,7 @@ class VariableCache(object):
     Typically used to recreate the neo object for one type of variable for
     one segment
     """
-    __slots__ = ("_data", "_ids", "_units")
+    __slots__ = ("_data", "_ids", "_units", "_sampling_interval")
 
     def __init__(self, data, ids, units, sampling_interval):
         """

--- a/spynnaker8/models/variable_cache.py
+++ b/spynnaker8/models/variable_cache.py
@@ -5,20 +5,20 @@ class VariableCache(object):
     Typically used to recreate the neo object for one type of variable for
     one segment
     """
-    __slots__ = ("_data", "_ids", "_units", "_sampling_interval")
+    __slots__ = ("_data", "_indexes", "_units", "_sampling_interval")
 
-    def __init__(self, data, ids, units, sampling_interval):
+    def __init__(self, data, indexes, units, sampling_interval):
         """
 
         :param data: raw data in spynakker format
         :type data: nparray
-        :param ids: ids for which data should be returned
+        :param indexes: Population indexes for which data should be returned
         :type nparray
         :param units: the units in which the data is
         :type units: str
         """
         self._data = data
-        self._ids = ids
+        self._indexes = indexes
         self._units = units
         self._sampling_interval = sampling_interval
 
@@ -27,8 +27,8 @@ class VariableCache(object):
         return self._data
 
     @property
-    def ids(self):
-        return self._ids
+    def indexes(self):
+        return self._indexes
 
     @property
     def units(self):

--- a/unittests/test_integration_using_virtual_baord/test_one_pop_lif_example.py
+++ b/unittests/test_integration_using_virtual_baord/test_one_pop_lif_example.py
@@ -21,6 +21,9 @@ def do_run(nNeurons):
 
     p.run(3000)
 
+    neo = pop1.get_data()
+    assert(neo is not None)
+
     p.end()
 
 


### PR DESCRIPTION
This avoids converting v ect data from a matrix to a list or (id, time, value) tuples and then back again for Neo.

Note: get_sampling_interval(self, variable): is in preparation for different ones per variable