### PR TITLE
improved handling of cases with zero spikes,

### DIFF
--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -348,6 +348,9 @@ class Recorder(RecordingCommon):
         :type label: str
         """
         # pylint: disable=too-many-arguments
+        if len(spikes) == 0:
+            return
+
         t_stop = t * quantities.ms
 
         if indexes is None:

--- a/spynnaker8/models/recorder.py
+++ b/spynnaker8/models/recorder.py
@@ -348,8 +348,9 @@ class Recorder(RecordingCommon):
         :type label: str
         """
         # pylint: disable=too-many-arguments
+        # Safety check in case spikes are an empty list
         if len(spikes) == 0:
-            return
+            spikes = numpy.empty(shape=(0, 2))
 
         t_stop = t * quantities.ms
 

--- a/spynnaker8/utilities/neo_convertor.py
+++ b/spynnaker8/utilities/neo_convertor.py
@@ -148,7 +148,7 @@ def convert_spiketrains(spiketrains):
     :rtype: nparray
     """
     if len(spiketrains) == 0:
-        return np.empty(shape=(0,2))
+        return np.empty(shape=(0, 2))
 
     neurons = np.concatenate(
         list(map(lambda x: np.repeat(x.annotations['source_index'], len(x)),

--- a/spynnaker8/utilities/neo_convertor.py
+++ b/spynnaker8/utilities/neo_convertor.py
@@ -147,6 +147,9 @@ def convert_spiketrains(spiketrains):
     :param spiketrains: List of SpikeTrains
     :rtype: nparray
     """
+    if len(spiketrains) == 0:
+        return np.empty(shape=(0,2))
+
     neurons = np.concatenate(
         list(map(lambda x: np.repeat(x.annotations['source_index'], len(x)),
              spiketrains)))


### PR DESCRIPTION
Thanks @SimonDavidson good spot.

The spike source array returns spikes as a list.
If there are no spikes an empty list is only 1 dimensional unlike the np.array size (0,2)  returned by neurone_recorder

Also fix for neo converter as like the recorder numpy does not like empty lists.