### PR TITLE
update pytest to version required for timeout

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 flake8
-pytest>=2.8
+pytest>=3.6
 pytest-cov
 pytest-timeout
 sphinx==1.5.3


### PR DESCRIPTION
Travis was complaining about the pytest version after the latest merge to master I did, so I've updated it.