### PR TITLE
No skip, and fix value in integration test

### DIFF
--- a/p8_integration_tests/test_if_curr_exp_live_buffers/test_synfire_if_curr_exp.py
+++ b/p8_integration_tests/test_if_curr_exp_live_buffers/test_synfire_if_curr_exp.py
@@ -1,7 +1,6 @@
 """
 Synfirechain-like example
 """
-import unittest
 from p8_integration_tests.base_test_case import BaseTestCase
 from p8_integration_tests.scripts.synfire_run import SynfireRunner
 import spynnaker.plot_utils as plot_utils

--- a/p8_integration_tests/test_if_curr_exp_live_buffers/test_synfire_if_curr_exp.py
+++ b/p8_integration_tests/test_if_curr_exp_live_buffers/test_synfire_if_curr_exp.py
@@ -15,14 +15,12 @@ synfire_run = SynfireRunner()
 
 class SynfireIfCurrExp(BaseTestCase):
 
-    @unittest.skip("https://github.com/SpiNNakerManchester/"
-                   "SpiNNFrontEndCommon/issues/162")
     def test_run(self):
         synfire_run.do_run(n_neurons, neurons_per_core=neurons_per_core,
                            run_times=[runtime], seed=self._test_seed)
         spikes = synfire_run.get_output_pop_spikes_numpy()
 
-        self.assertEquals(158, len(spikes))
+        self.assertEquals(263, len(spikes))
         spike_checker.synfire_spike_checker(spikes, n_neurons)
         synfire_run.get_output_pop_gsyn_exc_numpy()
         synfire_run.get_output_pop_voltage_numpy()


### PR DESCRIPTION
Been looking at integration tests for the synapse_expander_on_chip branch, discovered this one that was being skipped, but it now works (with the correct size for the spikes array).  I think the reason it was being skipped was fixed a while ago...