### PR TITLE
Move FromFileConnector to this repository, update test to be better

### DIFF
--- a/p8_integration_tests/test_from_file_connector/test_from_file_connector.py
+++ b/p8_integration_tests/test_from_file_connector/test_from_file_connector.py
@@ -47,11 +47,11 @@ def do_run(plot):
 
     # Set up fromfileconnectors by writing to file
     connection_list1 = [
-                (0, 0, 0.1, 0.1),
-                (3, 0, 0.2, 0.11),
-                (2, 3, 0.3, 0.12),
-                (5, 1, 0.4, 0.13),
-                (0, 1, 0.5, 0.14),
+                (0, 0, 0.1, 10),
+                (3, 0, 0.2, 11),
+                (2, 3, 0.3, 12),
+                (5, 1, 0.4, 13),
+                (0, 1, 0.5, 14),
                 ]
     path1 = "test1.connections"
     if os.path.exists(path1):
@@ -62,19 +62,22 @@ def do_run(plot):
     numpy.savetxt(file1, connection_list1)
     file_connector1 = p.FromFileConnector(file1)
 
+    # PyNN allows the column order (after i,j) to be different,
+    # so we can test that here
     connection_list2 = [
-                (4, 9, 0.3, 0.12),
-                (1, 5, 0.4, 0.13),
-                (7, 6, 0.1, 0.1),
-                (6, 5, 0.5, 0.14),
-                (8, 2, 0.2, 0.11),
+                (4, 9, 12, 0.3),
+                (1, 5, 13, 0.4),
+                (7, 6, 1, 0.1),
+                (6, 5, 14, 0.5),
+                (8, 2, 11, 0.2),
                 ]
     path2 = "test2.connections"
     if os.path.exists(path2):
         os.remove(path2)
 
     file2 = path2
-    numpy.savetxt(file2, connection_list2)
+    numpy.savetxt(file2, connection_list2,
+                  header='columns = ["i", "j", "delay", "weight"]')
     file_connector2 = p.FromFileConnector(file2)
 
     # Projections within populations
@@ -115,7 +118,7 @@ class FromFileConnectorTest(BaseTestCase):
         v, spikes = do_run(plot=False)
         # any checks go here
         spikes_test = neo_convertor.convert_spikes(spikes)
-        self.assertEquals(3, len(spikes_test))
+        self.assertEquals(2, len(spikes_test))
 
 
 if __name__ == '__main__':

--- a/spynnaker8/models/connectors/from_file_connector.py
+++ b/spynnaker8/models/connectors/from_file_connector.py
@@ -1,8 +1,7 @@
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from .from_list_connector import FromListConnector
 import os
 import numpy
-from six import add_metaclass, string_types
+from six import string_types
 
 from pyNN.connectors import FromFileConnector as PyNNFromFileConnector
 from pyNN.recording import files

--- a/spynnaker8/models/connectors/from_file_connector.py
+++ b/spynnaker8/models/connectors/from_file_connector.py
@@ -1,22 +1,58 @@
-from spynnaker.pyNN.models.neural_projections.connectors \
-    import FromFileConnector as CommonFromFileConnector
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from .from_list_connector import FromListConnector
+import os
+import numpy
+from six import add_metaclass, string_types
 
 from pyNN.connectors import FromFileConnector as PyNNFromFileConnector
 from pyNN.recording import files
 
 
-class FromFileConnector(CommonFromFileConnector, PyNNFromFileConnector):
+class FromFileConnector(FromListConnector, PyNNFromFileConnector):
     # pylint: disable=redefined-builtin
+    __slots__ = ["_file"]
+
     def __init__(
-            self, file, callback=None,  # @ReservedAssignment
-            distributed=False, safe=True, verbose=False):
+            self, file,  # @ReservedAssignment
+            distributed=False, safe=True, callback=None, verbose=False):
+        self._file = file
+        if isinstance(file, string_types):
+            real_file = self.get_reader(file)
+            try:
+                conn_list = self._read_conn_list(real_file, distributed)
+            finally:
+                real_file.close()
+        else:
+            conn_list = self._read_conn_list(file, distributed)
+
+        column_names = self.get_reader(self._file).get_metadata().get(
+            'columns')
+
         # pylint: disable=too-many-arguments
-        CommonFromFileConnector.__init__(
-            self, file=file, distributed=distributed, safe=safe,
-            verbose=verbose)
+        FromListConnector.__init__(
+            self, conn_list, safe=safe, verbose=verbose,
+            column_names=column_names, callback=callback)
         PyNNFromFileConnector.__init__(
             self, file=file, distributed=distributed, safe=safe,
             callback=callback)
+
+    def _read_conn_list(self, the_file, distributed):
+        if not distributed:
+            return the_file.read()
+        filename = "{}.".format(os.path.basename(the_file.file))
+
+        conns = list()
+        for found_file in os.listdir(os.path.dirname(the_file.file)):
+            if found_file.startswith(filename):
+                file_reader = self.get_reader(found_file)
+                try:
+                    conns.append(file_reader.read())
+                finally:
+                    file_reader.close()
+        return numpy.concatenate(conns)
+
+    def __repr__(self):
+        return "FromFileConnector({})".format(self._file)
 
     def get_reader(self, file):  # @ReservedAssignment
         """ Get a file reader object using the PyNN methods.


### PR DESCRIPTION
Fix for the FromFileConnector to work properly again: basically, it was wrapping around the FromListConnector, but missing certain elements of it.  This now also works with a column header where the weights and delays are not in the "usual" order.  I have also updated the integration test to cover this scenario.