### PR TITLE
get_time_step should return ms, not microseconds

### DIFF
--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -527,11 +527,11 @@ def get_max_delay():
 def get_time_step():
     """ The integration time step
 
-    :return: get the time step of the simulation
+    :return: get the time step of the simulation (in ms)
     """
     if not globals_variables.has_simulator():
         raise ConfigurationException(FAILED_STATE_MSG)
-    return __pynn["get_time_step"]()
+    return float(__pynn["get_time_step"]()) / 1000.0
 
 
 def initialize(cells, **initial_values):


### PR DESCRIPTION
Fixing https://github.com/SpiNNakerManchester/sPyNNaker/issues/147 - open to opinions over whether we need a named constant for this conversion, as we do perform similar conversions elsewhere in this repository and the sPyNNaker repository.