### PR TITLE
without cffconvert dependency

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
   email: Andrew.Gait@manchester.ac.uk
   family-names: Gait
   given-names: Andrew
-  orcid: http://orcid.org/0000-0001-9349-1096
+  orcid: https://orcid.org/0000-0001-9349-1096
   website: https://personalpages.manchester.ac.uk/staff/Andrew.Gait/
 - email: andreas.stoeckel@googlemail.com
   family-names: Stöckel
@@ -123,11 +123,11 @@ contact:
   country: GB
   name: SpiNNaker Software Team
   post-code: M13 9PL
-date-released:
-email: spinnakerusers@googlegroups.com
-identifier:
-message: If you use this software, please cite it as below.
+  email: spinnakerusers@googlegroups.com
+date-released: 2019-6-10 #FIXME
+#identifier:
+message: If you use this software, please cite it using the metadata from this file.
 repository: https://github.com/SpiNNakerManchester/sPyNNaker8
 title: The PyNN 0.8 / 0.9 Implementation for executing on SpiNNaker machines.
 url: http://spinnakermanchester.github.io/
-version:
+version: TODO

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,3 @@ pytest-cov
 pytest-timeout
 sphinx==1.5.3
 testfixtures
-cffconvert

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ appdirs >= 1.4.2 , < 2.0.0
 neo >= 0.5.2, < 0.7.0
 matplotlib
 csa
-cffconvert
 #spinnaker_tools


### PR DESCRIPTION
i think we can do without the cffconvert dependency (since it is not part of spynnaker, it is just a command line tool)

this PR is just a quick check to see if the build is green without me having to dive into the details of the project.

Of course feel free to accept or reject as you see fit.

I also edited the CFF file a bit to check if it is valid. Note that there are still violations in the CFF but those are due to errors in the schema (most notably email addresses). Before releasing, just add the ``date-released`` and ``version`` values and you're good to go.



