### PR TITLE
Delay in script too large, caught by sPyNNaker fix last week

### DIFF
--- a/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
+++ b/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
@@ -36,7 +36,7 @@ def do_run():
         p.StaticSynapse(weight=1, delay=1), receptor_type="excitatory")
     p.Projection(
         pop_src1, populations[0], p.OneToOneConnector(),
-        p.StaticSynapse(weight=1, delay=100), receptor_type="inhibitory")
+        p.StaticSynapse(weight=1, delay=10), receptor_type="inhibitory")
 
     populations[0].record("all")
     p.run(runtime)


### PR DESCRIPTION
The fix last week at https://github.com/SpiNNakerManchester/sPyNNaker/pull/748 uncovered an error in one of the sPyNNaker8 unit tests.