### PR TITLE
Fix failing microcircuit test

### DIFF
--- a/p8_integration_tests/quick_test/test_grid_based_connectors/test_small_world_connector.py
+++ b/p8_integration_tests/quick_test/test_grid_based_connectors/test_small_world_connector.py
@@ -150,6 +150,7 @@ class SmallWorldConnectorTest(BaseTestCase):
 
 
 if __name__ == '__main__':
-    v, spikes = do_run(plot=True)
+    v, spikes, weights = do_run(plot=True)
     print(len(neo_convertor.convert_data(v, name='v')))
     print(len(neo_convertor.convert_data(spikes, name='spikes')))
+    print(len(weights))

--- a/p8_integration_tests/scripts_test/test_microcircuit.py
+++ b/p8_integration_tests/scripts_test/test_microcircuit.py
@@ -37,7 +37,8 @@ class TestMicrocircuit(ScriptChecker):
         sys.path.append(microcircuit_dir)
         microcircuit_script = os.path.join(
             microcircuit_dir, "microcircuit.py")
-        os.makedirs("results")
+        if not os.path.exists("results"):
+            os.makedirs("results")
         self.check_script(microcircuit_script, False)
         for result_file in [
                 "spikes_L23E.pkl", "spikes_L23I.pkl",


### PR DESCRIPTION
test_microcircuit has been failing on the overnight cron job testing because there was no check as to whether the results directory existed already.  