### PR TITLE
Add multi-core test for OneToOne when using PopulationViews

### DIFF
--- a/p8_integration_tests/quick_test/test_connectors/test_connectors.py
+++ b/p8_integration_tests/quick_test/test_connectors/test_connectors.py
@@ -252,7 +252,7 @@ class ConnectorsTest(BaseTestCase):
         weights = conn.get(['weight', 'delay'], 'list')
         machine_graph = globals_variables.get_simulator()._machine_graph
         projection_edges = [edge for edge in machine_graph.edges if (
-            edge.label=='machine_edge_fortest')]
+            edge.label == 'machine_edge_fortest')]
         sim.end()
         # Check the connections are correct
         target = [(6, 9, 0.5, 2.), (7, 10, 0.5, 2.), (8, 11, 0.5, 2.),


### PR DESCRIPTION
Adding a multi-core test with PopulationViews for the OneToOneConnector, testing fix at https://github.com/SpiNNakerManchester/sPyNNaker/pull/779