### PR TITLE
skip examples which take over 100 seconds

### DIFF
--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -130,7 +130,7 @@ pipeline {
         stage('Run scripts') {
             steps {
                 sh 'python sPyNNaker8/p8_integration_tests/scripts_test/build_script.py'
-                run_pytest('sPyNNaker8/p8_integration_tests/scripts_test', 1200, 'sPyNNaker8Scripts')
+                run_pytest('sPyNNaker8/p8_integration_tests/scripts_test', 3600, 'sPyNNaker8Scripts')
             }
         }
         stage('Reports') {

--- a/p8_integration_tests/quick_test/test_connectors/test_connectors.py
+++ b/p8_integration_tests/quick_test/test_connectors/test_connectors.py
@@ -15,7 +15,6 @@
 
 import numpy
 import spynnaker8 as sim
-from spinn_front_end_common.utilities import globals_variables
 from spynnaker.pyNN.exceptions import SpynnakerException
 from p8_integration_tests.base_test_case import BaseTestCase
 from pyNN.random import NumpyRNG
@@ -238,32 +237,6 @@ class ConnectorsTest(BaseTestCase):
 
     def test_onetoone_population_views(self):
         self.runsafe(self.onetoone_population_views)
-
-    def onetoone_multicore_population_views(self):
-        sim.setup(timestep=1.0)
-        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 10)
-        sim.set_number_of_neurons_per_core(sim.SpikeSourceArray, 10)
-        input = sim.Population(14, sim.SpikeSourceArray([0]), label="input")
-        pop = sim.Population(17, sim.IF_curr_exp(), label="pop")
-        conn = sim.Projection(input[6:12], pop[9:16], sim.OneToOneConnector(),
-                              sim.StaticSynapse(weight=0.5, delay=2),
-                              label="test")
-        sim.run(1)
-        weights = conn.get(['weight', 'delay'], 'list')
-        machine_graph = globals_variables.get_simulator()._machine_graph
-        projection_edges = [edge for edge in machine_graph.edges if (
-            edge.label=='machine_edge_fortest')]
-        sim.end()
-        # Check the connections are correct
-        target = [(6, 9, 0.5, 2.), (7, 10, 0.5, 2.), (8, 11, 0.5, 2.),
-                  (9, 12, 0.5, 2.), (10, 13, 0.5, 2.), (11, 14, 0.5, 2.)]
-        self.assertEqual(weights.tolist(), target)
-        # In this instance there should be three MachineEdges: one of the four
-        # possible at the start should have been filtered out
-        self.assertEqual(len(projection_edges), 3)
-
-    def test_onetoone_multicore_population_views(self):
-        self.runsafe(self.onetoone_multicore_population_views)
 
     def fixedprob_population_views(self):
         sim.setup(timestep=1.0)

--- a/p8_integration_tests/scripts_test/build_script.py
+++ b/p8_integration_tests/scripts_test/build_script.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     introlab_script = os.path.join(tests_dir, "intro_labs_auto_test.py")
     introlab_header = os.path.join(tests_dir, "intro_labs_header.py")
     copyfile(introlab_header, introlab_script)
-    exceptions =  ["sudoku.py"]
+    exceptions = ["sudoku.py"]
     # Lazy boolean distinction based on presence or absence of a parameter
     if len(sys.argv) > 1:  # 1 is the script name
         # Skip the known long ones
@@ -84,7 +84,6 @@ if __name__ == '__main__':
         exceptions.append("balanced_random_live_rate")  # 125 seconds
         exceptions.append("stdp_curve.py")  # 118 seconds
         exceptions.append("stdp_curve_cond.py")  # 121 seconds
-
 
     with open(examples_script, "a") as examples_file:
         examples_file.write("# flake8: noqa\n")

--- a/p8_integration_tests/scripts_test/build_script.py
+++ b/p8_integration_tests/scripts_test/build_script.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import platform
 from shutil import copyfile
-import sys
 
 
 def add_scripts(a_dir, prefix_len, test_file, exceptions, broken):
@@ -27,14 +25,13 @@ def add_scripts(a_dir, prefix_len, test_file, exceptions, broken):
         if os.path.isdir(script_path) and not a_script.startswith("."):
             add_scripts(script_path, prefix_len, test_file, exceptions, broken)
         if a_script.endswith(".py"):
+            print(script_path)
             name = script_path[prefix_len:-3].replace(os.sep, "_")
+            print(name)
             test_file.write("\n    def ")
             test_file.write(name)
             test_file.write("(self):\n        self.check_script(\"")
-            the_path = os.path.abspath(script_path)
-            if platform.system() == "Windows":
-                the_path= the_path.replace("\\","/")
-            test_file.write(the_path)
+            test_file.write(os.path.abspath(script_path))
             if a_script in broken:
                 test_file.write("\", True)\n\n    def test_")
             else:
@@ -70,14 +67,10 @@ if __name__ == '__main__':
     examples_script = os.path.join(tests_dir, "examples_auto_test.py")
     examples_header = os.path.join(tests_dir, "examples_header.py")
     copyfile(examples_header, examples_script)
-    exceptions = ["pushbot_ethernet_example.py"]
-    if len(sys.argv) > 1:  # 1 is the script name
-        # Skip the known long ones
-        exceptions.append("stdp_triplet.py")
     with open(examples_script, "a") as examples_file:
         examples_file.write("# flake8: noqa\n")
         add_scripts(examples_dir, len(examples_dir)+1, examples_file,
-                    exceptions,
+                    ["pushbot_ethernet_example.py"],
                     ["synfire_if_curr_exp_large_array.py",
                      "vogels_2011.py",
                      "vogels_2011_live.py"])


### PR DESCRIPTION
Removes from pr test the script that took over 100 seconds to run each
Note: Longer scripts and the microcircuit are still in the crom job

This will reduce each test run by about 30 minutes