### PR TITLE
Update test to use seeded rng which should mean no occasional failures

### DIFF
--- a/p8_integration_tests/quick_test/test_grid_based_connectors/test_small_world_connector.py
+++ b/p8_integration_tests/quick_test/test_grid_based_connectors/test_small_world_connector.py
@@ -16,6 +16,7 @@
 import spynnaker8 as p
 from p8_integration_tests.base_test_case import BaseTestCase
 from pyNN.utility.plotting import Figure, Panel
+from pyNN.random import NumpyRNG
 import matplotlib.pyplot as plt
 from spynnaker8.utilities import neo_convertor
 
@@ -64,7 +65,9 @@ def do_run(plot):
     # Connectors
     degree = 2.0
     rewiring = 0.4
-    small_world_connector = p.SmallWorldConnector(degree, rewiring)
+    rng = NumpyRNG(seed=1)
+
+    small_world_connector = p.SmallWorldConnector(degree, rewiring, rng=rng)
 
     # Projection for small world grid
     sw_pro = p.Projection(small_world, small_world, small_world_connector,
@@ -130,7 +133,6 @@ class SmallWorldConnectorTest(BaseTestCase):
         three_step_connected = self.next_connected(
             two_step_connected, single_connected)
 
-        # There is a minor chance this fails so if it ever does add a skip
         for i in range(25):
             self.assertEqual(25, len(three_step_connected[i]))
 

--- a/spynnaker8/models/connectors/small_world_connector.py
+++ b/spynnaker8/models/connectors/small_world_connector.py
@@ -23,9 +23,11 @@ class SmallWorldConnector(_BaseClass):
 
     def __init__(
             self, degree, rewiring, allow_self_connections=True,
-            safe=True, verbose=False, n_connections=None):
+            n_connections=None, rng=None, safe=True, callback=None,
+            verbose=False):
         # pylint: disable=too-many-arguments
         super(SmallWorldConnector, self).__init__(
             degree=degree, rewiring=rewiring,
             allow_self_connections=allow_self_connections,
-            safe=safe, verbose=verbose, n_connections=n_connections)
+            n_connections=n_connections, rng=rng, safe=safe, callback=callback,
+            verbose=verbose)


### PR DESCRIPTION
Update occasionally failing test to use seeded RNG (which required updating the argument list, which may clash with some of the doc-changes... ?).