### PR TITLE
more agggressive cleanup on second setup

### DIFF
--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -348,8 +348,14 @@ def setup(timestep=_pynn_control.DEFAULT_TIMESTEP,
 
     # create stuff simulator
     if globals_variables.has_simulator():
+        logger.warning("Calling setup a second time causes the previous "
+                       "simulator to be stopped and cleared.")
         # if already exists, kill and rebuild
-        globals_variables.get_simulator().clear()
+        try:
+            globals_variables.get_simulator().clear()
+        except Exception:
+            logger.exception("Error forcing previous simulation to clear")
+            globals_variables.unset_simulator()
 
     # add default label if needed
     if graph_label is None:


### PR DESCRIPTION
We already allowed setup to be called twice
This cleared the previous run and before creating a new simulator

This now makes it even more rebost to failure.

Note this continues to have the same effect as doing a simulator.end

Reusing any object created with a previous sim.setup will cause weird errors. (with or without end)