### PR TITLE
Routing compression checker from a report to an Algorithm

### DIFF
--- a/p8_integration_tests/quick_test/test_debug_mode/check_debug.py
+++ b/p8_integration_tests/quick_test/test_debug_mode/check_debug.py
@@ -61,8 +61,6 @@ class CheckDebug(BaseTestCase):
             reports_names._ROUTING_TABLE_DIR,
             reports_names._C_ROUTING_TABLE_DIR,
             reports_names._COMPARED_FILENAME,
-            # write_routing_compression_checker_report
-            "routing_compression_checker_report.rpt",
             # write_routing_tables_from_machine_report
             routing_tables_from_machine_report,
             # write_memory_map_report


### PR DESCRIPTION
Turn of check for routing_compression_checker_report in debug mode as no longer a report.