### PR TITLE
Bypass problem with pytest-xdist 2.0.0 for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
                 // Additional requirements for testing here
                 // coverage version capped due to https://github.com/nedbat/coveragepy/issues/883
                 sh 'pip install python-coveralls "coverage>=5.0.0"'
-                sh 'pip install pytest-instafail pytest-xdist'
+                sh 'pip install pytest-instafail "pytest-xdist==1.34.0"'
                 // Java install
                 sh 'mvn -f JavaSpiNNaker package'
             }


### PR DESCRIPTION
Most recent pytest-xdist (2.0.0) has an error at the moment (see https://github.com/SpiNNakerManchester/sPyNNaker8/issues/434).  Fixing for now by going back to older version.