### PR TITLE
Add Link to Info

### DIFF
--- a/p8_integration_tests/quick_test/test_ignores/spynnaker.cfg
+++ b/p8_integration_tests/quick_test/test_ignores/spynnaker.cfg
@@ -4,3 +4,4 @@ down_cores = 3,0,-4:99,99,2:2,2,-19:3,3,4,127.0.0.1
 down_links = 3,3,4,127.0.0.1:5,5,2
 down_chips = 6,7:3,3,127.0.0.1
 
+repair_machine = True


### PR DESCRIPTION
Adds repair_machine=True to one of the tests, required now that things have changed.